### PR TITLE
Update bundles to contain abp.moment.js

### DIFF
--- a/src/AbpCompanyName.AbpProjectName.WebSpaAngular/App_Start/BundleConfig.cs
+++ b/src/AbpCompanyName.AbpProjectName.WebSpaAngular/App_Start/BundleConfig.cs
@@ -56,6 +56,7 @@ namespace AbpCompanyName.AbpProjectName.WebSpaAngular
                         "~/Abp/Framework/scripts/libs/abp.blockUI.js",
                         "~/Abp/Framework/scripts/libs/abp.spin.js",
                         "~/Abp/Framework/scripts/libs/abp.sweet-alert.js",
+                        "~/Abp/Framework/scripts/libs/abp.moment.js",
                         "~/Abp/Framework/scripts/libs/angularjs/abp.ng.js"
                     )
                 );


### PR DESCRIPTION
Looks like this file is missing since the last release. It leads to an error `cannot set utcClockProvider of undefined` as some variables are missing.