### PR TITLE
add fix xml log4net 

### DIFF
--- a/src/AbpCompanyName.AbpProjectName.WebMpa/log4net.config
+++ b/src/AbpCompanyName.AbpProjectName.WebMpa/log4net.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <log4net>
   <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender" >
     <file value="App_Data/Logs/Logs.txt" />

--- a/src/AbpCompanyName.AbpProjectName.WebSpaAngular/log4net.config
+++ b/src/AbpCompanyName.AbpProjectName.WebSpaAngular/log4net.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <log4net>
   <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender" >
     <file value="App_Data/Logs/Logs.txt" />


### PR DESCRIPTION
Issue #57

Hello everyone, the file `log4net.config` has a problem of ` ZERO WIDTH SPACE`,  this problem causes the file to become invalid.
Below the evidence of the error:

## Terminal: `dotnet run`

![error-console](https://cloud.githubusercontent.com/assets/1616798/24415070/a0351030-13b6-11e7-83c5-79ac105b1a58.JPG)

## Visual Studio
![error-1](https://cloud.githubusercontent.com/assets/1616798/24415071/a039819c-13b6-11e7-98bd-f860baf708b3.JPG)

## Github
![error-github](https://cloud.githubusercontent.com/assets/1616798/24415069/a032c33e-13b6-11e7-98ca-deadad77313e.JPG)
